### PR TITLE
A fix and a couple of additions...

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -22,6 +22,7 @@ def main():
     nodes = xmldoc.getElementsByTagName('SITE')
 
     xml_str = '<?xml version="1.0" encoding="UTF-8" standalone="yes" ?><FileZilla3><Servers>'
+    xml_str += '<Folder expanded="1">Imported from FlashFXP&#x0A;            '
 
     for node in nodes:
         name = node.attributes['NAME'].value
@@ -58,6 +59,7 @@ def main():
         xml_str += '<SyncBrowsing>0</SyncBrowsing>'+ str(name) +'&#x0A;                '
         xml_str += '</Server>'
 
+    xml_str += '</Folder>'
     xml_str += '</Servers></FileZilla3>'
 
     xml_output_file = open('filezilla.xml', 'w')


### PR DESCRIPTION
Thanks for the changes! Along the way I added and fixed a couple things myself, so I guess now a pull request is in order. I'm kinda new to the inner workings of GitHub and this pull request thing so if I'm doing something wrong please let me know.
- Most importantly; no idea why but import would fail without an extra name var right after `<SyncBrowsing>0</SyncBrowsing>`. I found out about this after comparing my FileZilla file with an export file created in FileZilla.
- Set port to 21 if value is missing.
- Added local and remote folder copy.
- Populated `<Comments>` tag with `Imported from FlashFXP`.
- Added default `Imported from FlashFXP`.

Tested in Mountain Lion with FileZilla 3.5.3.

Thanks!
